### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/AhmedMahmoudprod23/5492b820-cea2-4e71-8d14-08206579e3e9/4bcefd8d-88d2-4cc9-86dd-7e55f72b286a/_apis/work/boardbadge/b9d4a05f-5458-4b79-a450-5a756cf7cbce)](https://dev.azure.com/AhmedMahmoudprod23/5492b820-cea2-4e71-8d14-08206579e3e9/_boards/board/t/4bcefd8d-88d2-4cc9-86dd-7e55f72b286a/Microsoft.RequirementCategory)
 ## Your GitHub Learning Lab Repository for Intro to HTML
 
 Welcome to your repository for your GitHub Learning Lab course. This repository will be used during the different activities that I will be guiding you through.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/AhmedMahmoudprod23/5492b820-cea2-4e71-8d14-08206579e3e9/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.